### PR TITLE
WebApi topic - adding REST API for Carting (week2)

### DIFF
--- a/Carting/src/WebApi/Application/Carts/Queries/GetCart/GetCartQuery.cs
+++ b/Carting/src/WebApi/Application/Carts/Queries/GetCart/GetCartQuery.cs
@@ -8,6 +8,9 @@ namespace Carting.WebApi.Application.Carts.Queries.GetCart;
 
 public record GetCartQuery : IRequest<CartDto>
 {
+    /// <summary>
+    /// External id of the cart
+    /// </summary>
     public string CartId { get; init; }
 }
 

--- a/Carting/src/WebApi/Application/Common/Configuration/PersistenceOptions.cs
+++ b/Carting/src/WebApi/Application/Common/Configuration/PersistenceOptions.cs
@@ -2,5 +2,6 @@
 
 public class PersistenceOptions
 {
+    public const string PersistenceConfiguration = "PersistenceConfiguration";
     public string ConnectionString { get; set; }
 }

--- a/Carting/src/WebApi/ConfigureServices.cs
+++ b/Carting/src/WebApi/ConfigureServices.cs
@@ -59,9 +59,9 @@ public static class ConfigureServices
                 Description = "API for Carting-related operations"
             });
 
-            // using System.Reflection;
             var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
-            options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+            options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename), true);
+
             options.OperationFilter<SwaggerParameterFilters>();
             options.DocumentFilter<SwaggerVersionMapping>();
         });

--- a/Carting/src/WebApi/ConfigureServices.cs
+++ b/Carting/src/WebApi/ConfigureServices.cs
@@ -3,6 +3,7 @@ using Carting.WebApi.Application.Common.Behaviours;
 using Carting.WebApi.Application.Common.Configuration;
 using Carting.WebApi.Application.Common.Interfaces;
 using Carting.WebApi.Filters;
+using Carting.WebApi.Helpers;
 using Carting.WebApi.Infrastructure.Persistence;
 using Carting.WebApi.Infrastructure.Services;
 using Carting.WebApi.Swagger;
@@ -35,7 +36,13 @@ public static class ConfigureServices
         {
             options.Conventions.Add(new GroupingByNamespaceConvention());
         });
-        services.AddApiVersioning();
+
+        services.AddApiVersioning(config => {
+            config.DefaultApiVersion = new ApiVersion(1, 0);
+            config.ReportApiVersions = true;
+            config.AssumeDefaultVersionWhenUnspecified = true;
+        });
+
         services.AddSwaggerGen(options =>
         {
             options.SwaggerDoc("v1", new OpenApiInfo
@@ -55,6 +62,8 @@ public static class ConfigureServices
             // using System.Reflection;
             var xmlFilename = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
             options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, xmlFilename));
+            options.OperationFilter<SwaggerParameterFilters>();
+            options.DocumentFilter<SwaggerVersionMapping>();
         });
 
 

--- a/Carting/src/WebApi/Controllers/ApiControllerBase.cs
+++ b/Carting/src/WebApi/Controllers/ApiControllerBase.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace Carting.WebApi.Controllers;
 
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/v{version:apiVersion}/[controller]")]
 public abstract class ApiControllerBase : ControllerBase
 {
     private ISender _mediator = null!;

--- a/Carting/src/WebApi/Controllers/V1/CartController.cs
+++ b/Carting/src/WebApi/Controllers/V1/CartController.cs
@@ -17,10 +17,7 @@ public class CartsController : ApiControllerBase
     /// <remarks>
     /// Sample request:
     ///
-    ///     GET /
-    ///     {
-    ///        "CartId": 1
-    ///     }
+    ///     GET /Carts?CartId=1
     ///
     /// </remarks>
     /// <response code="200">Returns the cart</response>
@@ -44,7 +41,7 @@ public class CartsController : ApiControllerBase
     /// <remarks>
     /// Sample request:
     ///
-    ///     POST /some-id/Items
+    ///     POST /Carts/some-id/Items
     ///     {
     ///        "Id": 1,
     ///        "Name": "Some item name",
@@ -93,7 +90,7 @@ public class CartsController : ApiControllerBase
     /// <remarks>
     /// Sample request:
     ///
-    ///     POST /some-id/Items/1
+    ///     POST /Carts/some-id/Items/1
     ///     {
     ///        "Name": "Some item name",
     ///        "CurrencyCode": "EUR",

--- a/Carting/src/WebApi/Controllers/V1/CartController.cs
+++ b/Carting/src/WebApi/Controllers/V1/CartController.cs
@@ -1,0 +1,59 @@
+﻿using Carting.WebApi.Application.Carts.Queries.GetCart;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Carting.WebApi.Controllers.V1;
+
+[ApiVersion("1")]
+public class CartsController : ApiControllerBase
+{
+    /// <summary>
+    /// Returns a specific cart and its associated items
+    /// </summary>
+    /// <param name="query"></param>
+    /// <returns></returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     GET /
+    ///     {
+    ///        "CartId": 1
+    ///     }
+    ///
+    /// </remarks>
+    /// <response code="200">Returns the cart</response>
+    /// <response code="404">If the cart does not exist</response>
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [HttpGet]
+    public async Task<ActionResult<CartDto>> GetCart([FromQuery] GetCartQuery query)
+    {
+        return await Mediator.Send(query);
+    }
+
+    //[HttpPost]
+    //public async Task<ActionResult<int>> Create(CreateProductCommand command)
+    //{
+    //    return await Mediator.Send(command);
+    //}
+
+    //[HttpPut("{id}")]
+    //public async Task<ActionResult> Update(int id, UpdateProductCommand command)
+    //{
+    //    if (id != command.Id)
+    //    {
+    //        return BadRequest();
+    //    }
+
+    //    await Mediator.Send(command);
+
+    //    return NoContent();
+    //}
+
+    //[HttpDelete("{id}")]
+    //public async Task<ActionResult> Delete(int id)
+    //{
+    //    await Mediator.Send(new DeleteProductCommand() { Id = id });
+
+    //    return NoContent();
+    //}
+}

--- a/Carting/src/WebApi/Controllers/V1/CartController.cs
+++ b/Carting/src/WebApi/Controllers/V1/CartController.cs
@@ -1,4 +1,7 @@
-﻿using Carting.WebApi.Application.Carts.Queries.GetCart;
+﻿using Carting.WebApi.Application.Carts.Commands.AddItemToCart;
+using Carting.WebApi.Application.Carts.Commands.RemoveItemFromCartCommand;
+using Carting.WebApi.Application.Carts.Queries.GetCart;
+using Carting.WebApi.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Carting.WebApi.Controllers.V1;
@@ -22,38 +25,103 @@ public class CartsController : ApiControllerBase
     /// </remarks>
     /// <response code="200">Returns the cart</response>
     /// <response code="404">If the cart does not exist</response>
+    /// <response code="500">Server error</response>
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpGet]
     public async Task<ActionResult<CartDto>> GetCart([FromQuery] GetCartQuery query)
     {
         return await Mediator.Send(query);
     }
 
-    //[HttpPost]
-    //public async Task<ActionResult<int>> Create(CreateProductCommand command)
-    //{
-    //    return await Mediator.Send(command);
-    //}
+    /// <summary>
+    /// Adds an item to a specific cart. If there was no cart for the specifiec key, it creates the cart as well.
+    /// </summary>
+    /// <param name="cartId"></param>
+    /// <param name="command"></param>
+    /// <returns></returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     POST /some-id/Items
+    ///     {
+    ///        "Id": 1,
+    ///        "Name": "Some item name",
+    ///        "CurrencyCode": "EUR",
+    ///        "Price":5.99,
+    ///        "Quantity":2,
+    ///        "WebImage": {
+    ///           "Uri": "http://localhost/some-image-url.png",
+    ///           "AltText": "Missing image"
+    ///         }
+    ///     }
+    ///
+    /// </remarks>
+    /// <response code="201">Item created</response>
+    /// <response code="422">Request couldn't be processed - item is already added</response>
+    /// <response code="500">Server error</response>
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [Route("{cartId}/Items")]
+    [HttpPost]
+    public async Task<ActionResult> AddItemToCart(string cartId, AddItemToCartCommandDto command)
+    {
+        var addItemToCartCommand = new AddItemToCartCommand()
+        {
+            CartId = cartId,
+            Id = command.Id,
+            CurrencyCode = command.CurrencyCode,
+            Name = command.Name,
+            Price = command.Price,
+            Quantity = command.Quantity,
+            WebImage = command.WebImage
+        };
 
-    //[HttpPut("{id}")]
-    //public async Task<ActionResult> Update(int id, UpdateProductCommand command)
-    //{
-    //    if (id != command.Id)
-    //    {
-    //        return BadRequest();
-    //    }
+        await Mediator.Send(addItemToCartCommand);
 
-    //    await Mediator.Send(command);
+        return StatusCode(StatusCodes.Status201Created);
+    }
 
-    //    return NoContent();
-    //}
+    /// <summary>
+    /// Adds an item to a specific cart. If there was no cart for the specifiec key, it creates the cart as well.
+    /// </summary>
+    /// <param name="cartId"></param>
+    /// <param name="itemId"></param>
+    /// <returns></returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     POST /some-id/Items/1
+    ///     {
+    ///        "Name": "Some item name",
+    ///        "CurrencyCode": "EUR",
+    ///        "Price":5.99,
+    ///        "Quantity":2,
+    ///        "WebImage": {
+    ///           "Uri": "http://localhost/some-image-url.png",
+    ///           "AltText": "Missing image"
+    ///         }
+    ///     }
+    ///
+    /// </remarks>
+    /// <response code="200">Item deleted</response>
+    /// <response code="404">Item is not found</response>
+    /// <response code="500">Server error</response>
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [Route("{cartId}/Items/{itemId}")]
+    [HttpDelete]
+    public async Task<ActionResult> RemoveItemFromCart(string cartId, int itemId)
+    {
+        await Mediator.Send(new RemoveItemFromCartCommand()
+        {
+            Id = itemId,
+            CartId = cartId
+        });
 
-    //[HttpDelete("{id}")]
-    //public async Task<ActionResult> Delete(int id)
-    //{
-    //    await Mediator.Send(new DeleteProductCommand() { Id = id });
-
-    //    return NoContent();
-    //}
+        return Ok();
+    }
 }

--- a/Carting/src/WebApi/Controllers/V1/CartController.cs
+++ b/Carting/src/WebApi/Controllers/V1/CartController.cs
@@ -36,9 +36,9 @@ public class CartsController : ApiControllerBase
     }
 
     /// <summary>
-    /// Adds an item to a specific cart. If there was no cart for the specifiec key, it creates the cart as well.
+    /// Adds an item to a specific cart. If there was no cart for the specifiedkey, it creates the cart as well.
     /// </summary>
-    /// <param name="cartId"></param>
+    /// <param name="cartId">External id of the cart</param>
     /// <param name="command"></param>
     /// <returns></returns>
     /// <remarks>
@@ -85,10 +85,10 @@ public class CartsController : ApiControllerBase
     }
 
     /// <summary>
-    /// Adds an item to a specific cart. If there was no cart for the specifiec key, it creates the cart as well.
+    /// Adds an item to a specific cart. If there was no cart for the specifiedkey, it creates the cart as well.
     /// </summary>
-    /// <param name="cartId"></param>
-    /// <param name="itemId"></param>
+    /// <param name="cartId">External id of the cart</param>
+    /// <param name="itemId">External id of the item</param>
     /// <returns></returns>
     /// <remarks>
     /// Sample request:

--- a/Carting/src/WebApi/Controllers/V1/CartController.cs
+++ b/Carting/src/WebApi/Controllers/V1/CartController.cs
@@ -63,7 +63,7 @@ public class CartsController : ApiControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("{cartId}/Items")]
     [HttpPost]
-    public async Task<ActionResult> AddItemToCart(string cartId, AddItemToCartCommandDto command)
+    public async Task<ActionResult> AddItemToCart(string cartId, AddItemToCartDto command)
     {
         var addItemToCartCommand = new AddItemToCartCommand()
         {

--- a/Carting/src/WebApi/Controllers/V2/CartController.cs
+++ b/Carting/src/WebApi/Controllers/V2/CartController.cs
@@ -64,7 +64,7 @@ public class CartsController : ApiControllerBase
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [Route("{cartId}/Items")]
     [HttpPost]
-    public async Task<ActionResult> AddItemToCart(string cartId, AddItemToCartCommandDto command)
+    public async Task<ActionResult> AddItemToCart(string cartId, AddItemToCartDto command)
     {
         var addItemToCartCommand = new AddItemToCartCommand()
         {

--- a/Carting/src/WebApi/Controllers/V2/CartController.cs
+++ b/Carting/src/WebApi/Controllers/V2/CartController.cs
@@ -37,7 +37,7 @@ public class CartsController : ApiControllerBase
     }
 
     /// <summary>
-    /// Adds an item to a specific cart. If there was no cart for the specifiec key, it creates the cart as well.
+    /// Adds an item to a specific cart. If there was no cart for the specifiedkey, it creates the cart as well.
     /// </summary>
     /// <param name="cartId"></param>
     /// <param name="command"></param>
@@ -86,7 +86,7 @@ public class CartsController : ApiControllerBase
     }
 
     /// <summary>
-    /// Adds an item to a specific cart. If there was no cart for the specifiec key, it creates the cart as well.
+    /// Adds an item to a specific cart. If there was no cart for the specifiedkey, it creates the cart as well.
     /// </summary>
     /// <param name="cartId"></param>
     /// <param name="itemId"></param>

--- a/Carting/src/WebApi/Controllers/V2/CartController.cs
+++ b/Carting/src/WebApi/Controllers/V2/CartController.cs
@@ -17,10 +17,7 @@ public class CartsController : ApiControllerBase
     /// <remarks>
     /// Sample request:
     ///
-    ///     GET /
-    ///     {
-    ///        "CartId": 1
-    ///     }
+    ///     GET /Carts?CartId=1
     ///
     /// </remarks>
     /// <response code="200">Returns the cart</response>
@@ -45,7 +42,7 @@ public class CartsController : ApiControllerBase
     /// <remarks>
     /// Sample request:
     ///
-    ///     POST /some-id/Items
+    ///     POST /Carts/some-id/Items
     ///     {
     ///        "Id": 1,
     ///        "Name": "Some item name",
@@ -94,7 +91,7 @@ public class CartsController : ApiControllerBase
     /// <remarks>
     /// Sample request:
     ///
-    ///     POST /some-id/Items/1
+    ///     POST /Carts/some-id/Items/1
     ///     {
     ///        "Name": "Some item name",
     ///        "CurrencyCode": "EUR",

--- a/Carting/src/WebApi/Controllers/V2/CartController.cs
+++ b/Carting/src/WebApi/Controllers/V2/CartController.cs
@@ -1,0 +1,60 @@
+﻿using Carting.WebApi.Application.Carts.Queries.GetCart;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Carting.WebApi.Controllers.V2;
+
+[ApiVersion("2")]
+public class CartsController : ApiControllerBase
+{
+    /// <summary>
+    /// Returns a specific cart and its associated items
+    /// </summary>
+    /// <param name="query"></param>
+    /// <returns></returns>
+    /// <remarks>
+    /// Sample request:
+    ///
+    ///     GET /
+    ///     {
+    ///        "CartId": 1
+    ///     }
+    ///
+    /// </remarks>
+    /// <response code="200">Returns the cart</response>
+    /// <response code="404">If the cart does not exist</response>
+    //[ProducesResponseType(StatusCodes.Status200OK)]
+    //[ProducesResponseType(StatusCodes.Status404NotFound)]
+    [HttpGet]
+    public async Task<ActionResult<CartDto>> GetCart([FromQuery] GetCartQuery query)
+    {
+        return NoContent();
+        return await Mediator.Send(query);
+    }
+
+    //[HttpPost]
+    //public async Task<ActionResult<int>> Create(CreateProductCommand command)
+    //{
+    //    return await Mediator.Send(command);
+    //}
+
+    //[HttpPut("{id}")]
+    //public async Task<ActionResult> Update(int id, UpdateProductCommand command)
+    //{
+    //    if (id != command.Id)
+    //    {
+    //        return BadRequest();
+    //    }
+
+    //    await Mediator.Send(command);
+
+    //    return NoContent();
+    //}
+
+    //[HttpDelete("{id}")]
+    //public async Task<ActionResult> Delete(int id)
+    //{
+    //    await Mediator.Send(new DeleteProductCommand() { Id = id });
+
+    //    return NoContent();
+    //}
+}

--- a/Carting/src/WebApi/Domain/Entities/WebImage.cs
+++ b/Carting/src/WebApi/Domain/Entities/WebImage.cs
@@ -2,6 +2,13 @@
 
 public class WebImage
 {
+    /// <summary>
+    /// Uri of the image
+    /// </summary>
     public Uri Uri { get; set; }
+
+    /// <summary>
+    /// Alt text, it will be shown in case the client fails to load the image
+    /// </summary>
     public string AltText { get; set; }
 }

--- a/Carting/src/WebApi/Filters/ApiExceptionFilterAttribute.cs
+++ b/Carting/src/WebApi/Filters/ApiExceptionFilterAttribute.cs
@@ -15,6 +15,7 @@ public class ApiExceptionFilterAttribute : ExceptionFilterAttribute
             {
                 { typeof(ValidationException), HandleValidationException },
                 { typeof(NotFoundException), HandleNotFoundException },
+                { typeof(ItemAlreadyAddedToCartException), HandleItemAlreadyAddedToCartException },
             };
     }
 
@@ -39,6 +40,21 @@ public class ApiExceptionFilterAttribute : ExceptionFilterAttribute
             HandleInvalidModelStateException(context);
             return;
         }
+    }
+
+    private void HandleItemAlreadyAddedToCartException(ExceptionContext context)
+    {
+        var exception = (ItemAlreadyAddedToCartException)context.Exception;
+
+        var details = new ProblemDetails()
+        {
+            Title = "The specified resource has already been added.",
+            Detail = exception.Message
+        };
+
+        context.Result = new UnprocessableEntityObjectResult(details);
+
+        context.ExceptionHandled = true;
     }
 
     private void HandleValidationException(ExceptionContext context)

--- a/Carting/src/WebApi/Helpers/SwaggerParameterFilters.cs
+++ b/Carting/src/WebApi/Helpers/SwaggerParameterFilters.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+﻿using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Carting.WebApi.Helpers;
@@ -8,18 +6,11 @@ public class SwaggerParameterFilters : IOperationFilter
 {
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
-        try
-        {
-            var versionParameter = operation.Parameters.Single(p => p.Name == "version");
+        var versionParameter = operation.Parameters.Single(p => p.Name == "version");
 
-            if (versionParameter != null)
-            {
-                operation.Parameters.Remove(versionParameter);
-            }
-        }
-        catch (Exception ex)
+        if (versionParameter != null)
         {
-            Console.WriteLine(ex.Message);
+            operation.Parameters.Remove(versionParameter);
         }
     }
 }

--- a/Carting/src/WebApi/Helpers/SwaggerParameterFilters.cs
+++ b/Carting/src/WebApi/Helpers/SwaggerParameterFilters.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Carting.WebApi.Helpers;
+public class SwaggerParameterFilters : IOperationFilter
+{
+    public void Apply(OpenApiOperation operation, OperationFilterContext context)
+    {
+        try
+        {
+            var versionParameter = operation.Parameters.Single(p => p.Name == "version");
+
+            if (versionParameter != null)
+            {
+                operation.Parameters.Remove(versionParameter);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+        }
+    }
+}

--- a/Carting/src/WebApi/Helpers/SwaggerVersionMapping.cs
+++ b/Carting/src/WebApi/Helpers/SwaggerVersionMapping.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Carting.WebApi.Helpers;
+
+public class SwaggerVersionMapping : IDocumentFilter
+{
+    public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+    {
+        var pathLists = new OpenApiPaths();
+        IDictionary<string, OpenApiPaths> paths = new Dictionary<string, OpenApiPaths>();
+        var version = swaggerDoc.Info.Version.Replace("v", "").Replace("version", "").Replace("ver", "").Replace(" ", "");
+        foreach (var path in swaggerDoc.Paths)
+        {
+            pathLists.Add(path.Key.Replace("v{version}", swaggerDoc.Info.Version), path.Value);
+        }
+        swaggerDoc.Paths = pathLists;
+    }
+}

--- a/Carting/src/WebApi/Models/AddItemToCartCommandDto.cs
+++ b/Carting/src/WebApi/Models/AddItemToCartCommandDto.cs
@@ -1,0 +1,13 @@
+﻿using Carting.WebApi.Domain.Entities;
+
+namespace Carting.WebApi.Models;
+
+public class AddItemToCartCommandDto
+{
+    public int Id { get; init; }
+    public string Name { get; init; }
+    public WebImage? WebImage { get; init; }
+    public string CurrencyCode { get; init; }
+    public decimal Price { get; init; }
+    public int Quantity { get; init; }
+}

--- a/Carting/src/WebApi/Models/AddItemToCartCommandDto.cs
+++ b/Carting/src/WebApi/Models/AddItemToCartCommandDto.cs
@@ -4,10 +4,33 @@ namespace Carting.WebApi.Models;
 
 public class AddItemToCartCommandDto
 {
+    /// <summary>
+    /// Item id. Points to an Id in an external system
+    /// </summary>
     public int Id { get; init; }
+
+    /// <summary>
+    /// Well defined name of the item
+    /// </summary>
     public string Name { get; init; }
+
+    /// <summary>
+    /// Web image (optional)
+    /// </summary>
     public WebImage? WebImage { get; init; }
+
+    /// <summary>
+    /// 3-letter currency code
+    /// </summary>
     public string CurrencyCode { get; init; }
+
+    /// <summary>
+    /// Price, decimal
+    /// </summary>
     public decimal Price { get; init; }
+
+    /// <summary>
+    /// Quantity, integer
+    /// </summary>
     public int Quantity { get; init; }
 }

--- a/Carting/src/WebApi/Models/AddItemToCartDto.cs
+++ b/Carting/src/WebApi/Models/AddItemToCartDto.cs
@@ -2,7 +2,7 @@
 
 namespace Carting.WebApi.Models;
 
-public class AddItemToCartCommandDto
+public class AddItemToCartDto
 {
     /// <summary>
     /// Item id. Points to an Id in an external system

--- a/Carting/src/WebApi/Program.cs
+++ b/Carting/src/WebApi/Program.cs
@@ -1,6 +1,9 @@
+using Carting.WebApi.Application.Common.Configuration;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+builder.Services.AddConfig(builder.Configuration);
 builder.Services.AddApplicationServices();
 builder.Services.AddInfrastructureServices(builder.Configuration);
 builder.Services.AddWebApiServices();
@@ -22,10 +25,12 @@ app.UseHealthChecks("/health");
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 
-app.UseSwaggerUi3(settings =>
+app.UseSwagger();
+app.UseSwaggerUI(options =>
 {
-    settings.Path = "/api";
-    settings.DocumentPath = "/api/specification.json";
+    options.SwaggerEndpoint("/swagger/v1/swagger.json", "API v1");
+    options.SwaggerEndpoint("/swagger/v2/swagger.json", "API v2");
+    options.RoutePrefix = string.Empty;
 });
 
 app.UseRouting();
@@ -34,6 +39,10 @@ app.MapControllerRoute(
     name: "default",
     pattern: "{controller}/{action=Index}/{id?}");
 
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapControllers();
+});
 
 app.Run();
 

--- a/Carting/src/WebApi/Properties/launchSettings.json
+++ b/Carting/src/WebApi/Properties/launchSettings.json
@@ -13,16 +13,14 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/Carting/src/WebApi/Swagger/GroupingByNamespaceConvention.cs
+++ b/Carting/src/WebApi/Swagger/GroupingByNamespaceConvention.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace Carting.WebApi.Swagger;
+
+public class GroupingByNamespaceConvention : IControllerModelConvention
+{
+    public void Apply(ControllerModel controller)
+    {
+        var controllerNamespace = controller.ControllerType.Namespace;
+        var apiVersion = controllerNamespace.Split(".").Last().ToLower();
+        if (!apiVersion.StartsWith("v")) { apiVersion = "v1"; }
+        controller.ApiExplorer.GroupName = apiVersion;
+    }
+}

--- a/Carting/src/WebApi/WebApi.csproj
+++ b/Carting/src/WebApi/WebApi.csproj
@@ -6,21 +6,14 @@
         <AssemblyName>Carting.WebApi</AssemblyName>
         <Nullable>enable</Nullable>
         <IsPackable>true</IsPackable>
-        <SpaRoot>ClientApp\</SpaRoot>
-        <SpaProxyServerUrl>https://localhost:44447</SpaProxyServerUrl>
-        <SpaProxyLaunchCommand>npm start</SpaProxyLaunchCommand>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>efad71c6-743c-4b87-9de8-f26d77146f6d</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.5" />
-        <PackageReference Include="NSwag.AspNetCore" Version="13.16.0" />
-        <PackageReference Include="NSwag.MSBuild" Version="13.16.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
       <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.3.4" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
@@ -28,13 +21,15 @@
       <PackageReference Include="MediatR" Version="9.0.0" />
       <PackageReference Include="LiteDB" Version="5.0.11" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+      <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
     </ItemGroup>
 
     <PropertyGroup>
         <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     </PropertyGroup>
 
-    <!--<Target Name="NSwag" AfterTargets="PostBuildEvent" Condition=" '$(Configuration)' == 'Debug' ">
-        <Exec WorkingDirectory="$(ProjectDir)" EnvironmentVariables="ASPNETCORE_ENVIRONMENT=Development" Command="$(NSwagExe_Net60) run nswag.json /variables:Configuration=$(Configuration)" />
-    </Target>-->
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/Carting/src/WebApi/WebApi.csproj
+++ b/Carting/src/WebApi/WebApi.csproj
@@ -11,9 +11,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.5" />
+      <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
+      <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.5" />
       <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.3.4" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />

--- a/Carting/src/WebApi/appsettings.json
+++ b/Carting/src/WebApi/appsettings.json
@@ -4,5 +4,8 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "PersistenceConfiguration": {
+    "ConnectionString": ".\\CartingDb.db"
+  }
 }

--- a/Carting/src/WebApi/nswag.json
+++ b/Carting/src/WebApi/nswag.json
@@ -46,7 +46,6 @@
       "createWebHostBuilderMethod": null,
       "startupType": null,
       "allowNullableBodyParameters": true,
-      "output": "wwwroot/api/specification.json",
       "outputType": "OpenApi3",
       "assemblyPaths": [],
       "assemblyConfig": null,


### PR DESCRIPTION
Adding REST WebApi for Carting microservice.
Using Swashbuckle for OpenAPI documentation & UI.
Adding XML-docs API documentation generation on build.

Two supported API versions:

**Version 1**

Get cart info.
Input params: cart unique Key (string).
Returns a cart model (cart key + list of cart items).

Add item to cart.
Input params: cart unique Key (string) + cart item model.
Returns 200 if item was added to the cart. If there was no cart for specified key – creates it. Otherwise returns a corresponding HTTP code.

Delete item from cart.
Input params: cart unique key (string) and item id (int).
Returns 200 if item was deleted, otherwise returns corresponding HTTP code.


**Version 2** 
The same as Version 1 but with the following changes:
Get cart info returns a list of cart items instead of cart model.