### PR TITLE
Observability - adding Azure Application Insights

### DIFF
--- a/ApiGateway/ApiGateway/ApiGateway.csproj
+++ b/ApiGateway/ApiGateway/ApiGateway.csproj
@@ -7,15 +7,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Controllers\**" />
+    <Content Remove="Controllers\**" />
+    <EmbeddedResource Remove="Controllers\**" />
+    <None Remove="Controllers\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.7" />
     <PackageReference Include="MMLib.SwaggerForOcelot" Version="5.2.0" />
     <PackageReference Include="Ocelot" Version="18.0.0" />
     <PackageReference Include="Ocelot.Cache.CacheManager" Version="18.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Controllers\" />
   </ItemGroup>
 
 </Project>

--- a/ApiGateway/ApiGateway/Program.cs
+++ b/ApiGateway/ApiGateway/Program.cs
@@ -6,6 +6,7 @@ builder.Configuration.AddJsonFile("ocelot.json")
               .AddEnvironmentVariables();
 
 builder.Services.AddServices(builder.Configuration);
+builder.Services.AddApplicationInsightsTelemetry();
 
 var app = builder.Build();
 

--- a/ApiGateway/ApiGateway/Properties/serviceDependencies.json
+++ b/ApiGateway/ApiGateway/Properties/serviceDependencies.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights"
+    }
+  }
+}

--- a/ApiGateway/ApiGateway/Properties/serviceDependencies.local.json
+++ b/ApiGateway/ApiGateway/Properties/serviceDependencies.local.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights.sdk"
+    }
+  }
+}

--- a/Carting/src/WebApi/Infrastructure/Consumers/ProductPriceChangedEventConsumer.cs
+++ b/Carting/src/WebApi/Infrastructure/Consumers/ProductPriceChangedEventConsumer.cs
@@ -15,10 +15,7 @@ internal sealed class ProductPriceChangedIntegrationEventConsumer :
     private readonly ICartingDbContext _context;
     private readonly ILogger<ProductPriceChangedIntegrationEventConsumer> _logger;
     private readonly TelemetryConfiguration _telemetryConfiguration;
-    private static readonly DiagnosticListener DiagnosticListener = new DiagnosticListener(RabbitMQDiagnosticSourceName);
 
-
-    public const string RabbitMQDiagnosticSourceName = "Microsoft.Azure.ServiceBus";
     public ProductPriceChangedIntegrationEventConsumer(ICartingDbContext context, ILogger<ProductPriceChangedIntegrationEventConsumer> logger, IConfiguration configuration)
     {
         _context = context;

--- a/Carting/src/WebApi/Infrastructure/Persistence/CartingDbContext.cs
+++ b/Carting/src/WebApi/Infrastructure/Persistence/CartingDbContext.cs
@@ -1,6 +1,9 @@
 ﻿using Carting.WebApi.Application.Common.Configuration;
 using Carting.WebApi.Application.Common.Interfaces;
 using LiteDB;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Options;
 
 namespace Carting.WebApi.Infrastructure.Persistence;
@@ -8,44 +11,71 @@ namespace Carting.WebApi.Infrastructure.Persistence;
 public class CartingDbContext : ICartingDbContext
 {
     private readonly IOptions<PersistenceOptions> _persistenceConfiguration;
+    private readonly TelemetryConfiguration _telemetryConfiguration;
 
-    public CartingDbContext(IOptions<PersistenceOptions> persistenceConfiguration)
+    public CartingDbContext(IOptions<PersistenceOptions> persistenceConfiguration, IConfiguration configuration)
     {
         _persistenceConfiguration = persistenceConfiguration;
+        _telemetryConfiguration = TelemetryConfiguration.CreateDefault();
+        _telemetryConfiguration.ConnectionString = configuration["ApplicationInsights:ConnectionString"];
     }
 
     public T Get<T>(string id)
     {
-        using var db = new LiteDatabase(_persistenceConfiguration.Value.ConnectionString);
+        var telemetryClient = new TelemetryClient(_telemetryConfiguration);
+        using (var operation = telemetryClient.StartOperation<DependencyTelemetry>("LiteDb"))
+        {
+            operation.Telemetry.Type = "NoSQL";
+            using var db = new LiteDatabase(_persistenceConfiguration.Value.ConnectionString);
 
-        var col = db.GetCollection<T>(typeof(T).Name);
-        var result = col.FindById(id);
+            var col = db.GetCollection<T>(typeof(T).Name);
+            var result = col.FindById(id);
 
-        return result;
+            return result;
+        }
+
     }
 
-    public IEnumerable<T> GetAll<T>(Func<T,bool> pred)
+    public IEnumerable<T> GetAll<T>(Func<T, bool> pred)
     {
-        using var db = new LiteDatabase(_persistenceConfiguration.Value.ConnectionString);
+        var telemetryClient = new TelemetryClient(_telemetryConfiguration);
+        using (var operation = telemetryClient.StartOperation<DependencyTelemetry>("LiteDb"))
+        {
+            operation.Telemetry.Type = "NoSQL";
+            using var db = new LiteDatabase(_persistenceConfiguration.Value.ConnectionString);
 
-        var col = db.GetCollection<T>(typeof(T).Name);
+            var col = db.GetCollection<T>(typeof(T).Name);
 
-        return col.FindAll().Where(pred).ToList();
+            return col.FindAll().Where(pred).ToList();
+        }
+
     }
 
     public void Insert<T>(T entity, CancellationToken cancellationToken)
     {
-        using var db = new LiteDatabase(_persistenceConfiguration.Value.ConnectionString);
+        var telemetryClient = new TelemetryClient(_telemetryConfiguration);
+        using (var operation = telemetryClient.StartOperation<DependencyTelemetry>("LiteDb"))
+        {
+            operation.Telemetry.Type = "NoSQL";
+            using var db = new LiteDatabase(_persistenceConfiguration.Value.ConnectionString);
 
-        var col = db.GetCollection<T>(typeof(T).Name);
-        col.Insert(entity);
+            var col = db.GetCollection<T>(typeof(T).Name);
+            col.Insert(entity);
+        }
+
     }
 
     public void Update<T>(T entity)
     {
-        using var db = new LiteDatabase(_persistenceConfiguration.Value.ConnectionString);
+        var telemetryClient = new TelemetryClient(_telemetryConfiguration);
+        using (var operation = telemetryClient.StartOperation<DependencyTelemetry>("LiteDb"))
+        {
+            operation.Telemetry.Type = "NoSQL";
+            using var db = new LiteDatabase(_persistenceConfiguration.Value.ConnectionString);
 
-        var col = db.GetCollection<T>(typeof(T).Name);
-        col.Update(entity);
+            var col = db.GetCollection<T>(typeof(T).Name);
+            col.Update(entity);
+        }
+
     }
 }

--- a/Carting/src/WebApi/Program.cs
+++ b/Carting/src/WebApi/Program.cs
@@ -7,6 +7,7 @@ builder.Services.AddConfig(builder.Configuration);
 builder.Services.AddApplicationServices();
 builder.Services.AddInfrastructureServices(builder.Configuration);
 builder.Services.AddWebApiServices();
+builder.Services.AddApplicationInsightsTelemetry();
 
 var app = builder.Build();
 

--- a/Carting/src/WebApi/Properties/serviceDependencies.json
+++ b/Carting/src/WebApi/Properties/serviceDependencies.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights"
+    }
+  }
+}

--- a/Carting/src/WebApi/Properties/serviceDependencies.local.json
+++ b/Carting/src/WebApi/Properties/serviceDependencies.local.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights.sdk"
+    }
+  }
+}

--- a/Carting/src/WebApi/WebApi.csproj
+++ b/Carting/src/WebApi/WebApi.csproj
@@ -14,6 +14,7 @@
       <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
       <PackageReference Include="MassTransit.RabbitMQ" Version="8.0.3" />
       <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
+      <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
       <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.5" />
       <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
@@ -23,7 +24,9 @@
       <PackageReference Include="MediatR" Version="9.0.0" />
       <PackageReference Include="LiteDB" Version="5.0.11" />
       <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.21.0" />
       <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
+
     </ItemGroup>
 
     <ItemGroup>

--- a/Carting/src/WebApi/WebApi.csproj
+++ b/Carting/src/WebApi/WebApi.csproj
@@ -13,6 +13,7 @@
     <ItemGroup>
       <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
       <PackageReference Include="MassTransit.RabbitMQ" Version="8.0.3" />
+      <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
       <PackageReference Include="Microsoft.AspNetCore.SpaProxy" Version="6.0.5" />
       <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />

--- a/Catalog/src/Application/Application.csproj
+++ b/Catalog/src/Application/Application.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.3.4" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+        <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.5" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>

--- a/Catalog/src/Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Catalog/src/Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -37,6 +37,14 @@ namespace Catalog.Infrastructure.Persistence.Migrations
                     b.Property<DateTime?>("PublishedDate")
                         .HasColumnType("datetime2");
 
+                    b.Property<string>("TraceParentId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("TraceRootId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
                     b.HasKey("Id");
 
                     b.ToTable("OutboxMessages");

--- a/Catalog/src/WebApi/Program.cs
+++ b/Catalog/src/WebApi/Program.cs
@@ -6,6 +6,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddApplicationServices();
 builder.Services.AddInfrastructureServices(builder.Configuration);
 builder.Services.AddWebApiServices(builder.Configuration);
+builder.Services.AddApplicationInsightsTelemetry();
 
 var app = builder.Build();
 

--- a/Catalog/src/WebApi/Properties/serviceDependencies.json
+++ b/Catalog/src/WebApi/Properties/serviceDependencies.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights"
+    }
+  }
+}

--- a/Catalog/src/WebApi/Properties/serviceDependencies.local.json
+++ b/Catalog/src/WebApi/Properties/serviceDependencies.local.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "appInsights1": {
+      "type": "appInsights.sdk"
+    }
+  }
+}

--- a/Catalog/src/WebApi/WebApi.csproj
+++ b/Catalog/src/WebApi/WebApi.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="2.2.0" />

--- a/Contracts/Messaging.Contracts/IntegrationEvent.cs
+++ b/Contracts/Messaging.Contracts/IntegrationEvent.cs
@@ -22,4 +22,10 @@ public class IntegrationEvent
 
     [JsonInclude]
     public DateTime CreationDate { get; private init; }
+
+    [JsonInclude]
+    public string TraceRootId { get; set; }
+
+    [JsonInclude]
+    public string TraceParentId { get; set; }
 }

--- a/Contracts/Messaging.Contracts/ProductDeletedIntegrationEvent.cs
+++ b/Contracts/Messaging.Contracts/ProductDeletedIntegrationEvent.cs
@@ -4,8 +4,10 @@ public class ProductDeletedIntegrationEvent : IntegrationEvent
 {
     public int ProductId { get; private init; }
 
-    public ProductDeletedIntegrationEvent(int productId)
+    public ProductDeletedIntegrationEvent(int productId, string traceRootId, string traceParentId)
     {
         ProductId = productId;
+        TraceParentId = traceParentId;
+        TraceRootId = traceRootId;
     }
 }

--- a/Contracts/Messaging.Contracts/ProductPriceChangedIntegrationEvent.cs
+++ b/Contracts/Messaging.Contracts/ProductPriceChangedIntegrationEvent.cs
@@ -8,10 +8,12 @@ public class ProductPriceChangedIntegrationEvent : IntegrationEvent
 
     public decimal OldPrice { get; private init; }
 
-    public ProductPriceChangedIntegrationEvent(int productId, decimal newPrice, decimal oldPrice)
+    public ProductPriceChangedIntegrationEvent(int productId, decimal newPrice, decimal oldPrice, string traceRootId, string traceParentId) 
     {
         ProductId = productId;
         NewPrice = newPrice;
         OldPrice = oldPrice;
+        TraceParentId = traceParentId;
+        TraceRootId = traceRootId;
     }
 }


### PR DESCRIPTION
I'm not committing the Application Insights instrumentation key to the appsettings files.

```
  "ApplicationInsights": {
    "InstrumentationKey": "<<secret>>",
    "ConnectionString": "<<secret>>"
  }
```

Basically it seems that setting up Application Insights is really easy and it gives the distributed tracing option out of the box. Sharing an example for that:

![image](https://user-images.githubusercontent.com/3629167/181796781-a683c1f4-8b06-46c3-9687-9cbf3ee38cdb.png)
It can be seen that the appligation gateway is called (localhost:7028), which then calls the Catalog service (localhost:5021) twice (once for Product details, once for Product properties). Product properties are hard coded but it checks for the existence of the product so that's why there is a call to the CatalogDb.

Overview of the basic metrics: 
![image](https://user-images.githubusercontent.com/3629167/181797279-213ccb71-2764-4921-8435-5b8300c88c40.png)


Update: based on the discussion I've implemented custom tracing for RabbitMQ.
It looks like this for a product update which is propagated to the Carting service: 
![tracing_fullflow](https://user-images.githubusercontent.com/3629167/183245992-96da09f3-b6fa-4fc0-9042-a2029d03ea46.png)

And the background outbox service: 
![DistributedTracing](https://user-images.githubusercontent.com/3629167/183246013-7136c93a-f356-4dd6-8fb4-702b0dbebe77.png)

